### PR TITLE
Updated inversion-fixes.config for github header.

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -628,6 +628,9 @@ header {
 .Header .header-search-wrapper {
     background-color: rgba(0, 0, 0, 0.125) !important;
 }
+.js-selected-navigation-item {
+    color: rgba(0, 0, 0, 0.75) !important;
+}
 header,
 .HeaderNavlink,
 .Header .header-search-input,


### PR DESCRIPTION
Github text header ( e.g. Issues / Pull Requests  ... ) is not very legible in dark theme. It's black text in a greyish background.
This rule makes the text white.